### PR TITLE
An example that includes tail calls when compiled

### DIFF
--- a/tail-call.c
+++ b/tail-call.c
@@ -1,0 +1,31 @@
+/* Compile with gcc -g3 -O3 -o tail-call tail-call.c */
+#include <stdio.h>
+
+static int __attribute__((noinline))
+tail_callee(int a)
+{
+    printf("%d\n", a);
+    return a * a;
+}
+
+static int __attribute__((noinline))
+tail_caller_1(int a)
+{
+    return tail_callee(a + 1);
+}
+
+static int __attribute__((noinline))
+tail_caller_2(int a)
+{
+    return tail_callee(a + 2);
+}
+
+int main(void)
+{
+    int a = 42;
+
+    a = tail_caller_1(a);
+    a = tail_caller_2(a);
+
+    return tail_callee(a);
+}


### PR DESCRIPTION
When compiled with gcc -O3 (and probably lower levels) this will include tail calls. GDB 10 doesn't show up the call stack correctly, but GDB 13 does. Which is nice.